### PR TITLE
Update deps, use edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["cbor", "tokio", "framing"]
 categories = ["asynchronous", "network-programming"]
 license = "Apache-2.0/MIT"
+edition = "2018"
 
 [badges]
 maintenance = { status = "passively-maintained" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ appveyor = { repository = "vorner/tokio-serde-cbor" }
 [dependencies]
 bytes = "~0.4"
 serde = "~1"
-serde_cbor = "~0.9"
+serde_cbor = "~0.10"
 tokio-io = "~0.1"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use bytes::BytesMut;
 use serde::{Deserialize, Serialize};
 use serde_cbor::de::{Deserializer, IoRead};
 use serde_cbor::error::Error as CborError;
-use serde_cbor::ser::Serializer;
+use serde_cbor::ser::{IoWrite, Serializer};
 use tokio_io::codec::{Decoder as IoDecoder, Encoder as IoEncoder};
 
 /// Errors returned by encoding and decoding.
@@ -223,9 +223,9 @@ impl<Item: Serialize> IoEncoder for Encoder<Item> {
     fn encode(&mut self, item: Item, dst: &mut BytesMut) -> Result<(), Error> {
         let writer = BytesWriter(dst);
         let mut serializer = if self.packed {
-            Serializer::packed(writer)
+            Serializer::new(IoWrite::new(writer)).packed_format()
         } else {
-            Serializer::new(writer)
+            Serializer::new(IoWrite::new(writer))
         };
         if self.sd != SdMode::Never {
             serializer.self_describe()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,6 @@
 //! in some other way (eg. length-prefix encoding) and CBOR is only the payload, you'd use a codec
 //! for the other framing and use `.map` on the received stream and sink to convert the messages.
 
-extern crate bytes;
-extern crate serde;
-extern crate serde_cbor;
-extern crate tokio_io;
-
 use std::default::Default;
 use std::error::Error as ErrorTrait;
 use std::fmt::{Display, Formatter, Result as FmtResult};
@@ -64,7 +59,7 @@ impl Display for Error {
 }
 
 impl ErrorTrait for Error {
-    fn cause(&self) -> Option<&ErrorTrait> {
+    fn cause(&self) -> Option<&dyn ErrorTrait> {
         match self {
             Error::Io(e) => Some(e),
             Error::Cbor(e) => Some(e),


### PR DESCRIPTION
This is a mindless chore PR:

- update to edition 2018
- update serde_cbor to 0.10

----
I ended up doing this because I was having a look to see what it would take to port this to futures-codec to frame AsyncRead/AsyncWrite from futures 0.3. It turned out that after this PR, it literally just takes changing:

`use tokio_io::codec::{Decoder as IoDecoder, Encoder as IoEncoder};`

into:

`use futures_codec::{Decoder as IoDecoder, Encoder as IoEncoder};`

At least is compiles and the tests run. I'll go and play with it a bit!