### PR TITLE
Support futures_codec as well as tokio-codec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ bytes = "~0.4"
 serde = "~1"
 serde_cbor = "~0.10"
 tokio-io = "~0.1"
+futures_codec = { version = "~0.2", optional = true }
 
 [dev-dependencies]
-tokio    = "~0.1"
+tokio = "~0.1"
+runtime = "~0.3.0-alpha"
+futures-preview = "=0.3.0-alpha.17"
+

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ turning an async read/write into a stream and sink of objects.
 
 The API documentation can be found [here](https://docs.rs/tokio-serde-cbor).
 
+## Features
+This crate has an optional dependency: `futures_codec`. When enabled it will allow you to frame
+`AsyncRead`/`AsyncWrite` from the futures 0.3 crate. See the `futures` example in the example directory.
+
 ## Status
 
 The API is not formally stabilized and may change. But the crate itself is

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,6 +1,3 @@
-extern crate tokio;
-extern crate tokio_serde_cbor;
-
 use std::net::{TcpListener as StdTcpListener, TcpStream as StdTcpStream};
 
 use tokio::codec::Decoder;

--- a/examples/futures.rs
+++ b/examples/futures.rs
@@ -1,0 +1,77 @@
+//! Example demonstration how to use the codec with futures 0.3 networking and the futures_codec crate.
+//! Run with `cargo run --example futures --feature futures_codec`.
+
+#![feature(async_await)]
+
+type Error = Box<dyn std::error::Error + Send + Sync>;
+
+#[cfg(feature="futures_codec")]
+#[runtime::main]
+async fn main() -> Result<(), Error> {
+    use {runtime::net::{TcpListener, TcpStream}};
+    use futures::{SinkExt, StreamExt};
+    use futures_codec::Framed;
+    use tokio_serde_cbor::Codec;
+    use std::collections::HashMap;
+
+    // We create some test data to serialize. This works because Serde implements
+    // Serialize and Deserialize for HashMap, so the codec can frame this type.
+    type TestData = HashMap<String, usize>;
+
+    /// Something to test with. It doesn't really matter what it is.
+    fn test_data() -> TestData {
+        let mut data = HashMap::new();
+        data.insert("hello".to_owned(), 42);
+        data.insert("world".to_owned(), 0);
+        data
+    }
+
+    /// Creates a connected pair of sockets.
+    async fn socket_pair() -> Result<(TcpStream, TcpStream), Error> {
+        // port 0 = let the OS choose
+        let mut listener = TcpListener::bind("127.0.0.1:0")?;
+        let stream1 = TcpStream::connect(listener.local_addr()?);
+        let stream2 = listener.accept();
+        Ok((stream1.await?, stream2.await?.0))
+    }
+
+    // This creates a pair of TCP domain sockets that are connected together.
+    let (sender_socket, receiver_socket) = socket_pair().await?;
+
+    // This is the data we will send over.
+    let msg1 = test_data();
+    let msg2 = test_data();
+
+    // a task for the sender
+    let send_task = async move {
+        let mut sender = Framed::new( sender_socket, Codec::<TestData, TestData>::new() );
+        sender.send(msg1).await?;
+        sender.send(msg2).await?;
+
+        // unfortunately we have to annotate the type here if we want to
+        // use the '?' operator inside the async block.
+        let res: Result<(), Error> = Ok(());
+        res
+    };
+
+    // a separate task for the receiver. If would like this to run longer, you would spawn it,
+    // but here we send first, then receive, so we just await to keep it simple.
+    let receive_task = async move {
+        let mut receiver = Framed::new( receiver_socket, Codec::<TestData, TestData>::new() );
+        while let Some(msg) = receiver.next().await.transpose()? {
+            println!("Received: {:#?}", msg);
+        }
+        // the compiler can infer the result type here since we return it from main() which has annotated types.
+        Ok(())
+    };
+
+    send_task.await?;
+    receive_task.await
+}
+
+
+#[cfg(not(feature="futures_codec"))]
+fn main() -> Result<(), Error>
+{
+    Err( "Please run this example with --feature futures_codec".into() )
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,10 @@
 //! Note that this is useful if the CBOR itself defines the frames. If the messages are delimited
 //! in some other way (eg. length-prefix encoding) and CBOR is only the payload, you'd use a codec
 //! for the other framing and use `.map` on the received stream and sink to convert the messages.
+//!
+//! ## Features
+//! This crate has an optional dependency: `futures_codec`. When enabled it will allow you to frame
+//! `AsyncRead`/`AsyncWrite` from the futures 0.3 crate. See the `futures` example in the example directory.
 
 use std::default::Default;
 use std::error::Error as ErrorTrait;
@@ -25,7 +29,12 @@ use serde::{Deserialize, Serialize};
 use serde_cbor::de::{Deserializer, IoRead};
 use serde_cbor::error::Error as CborError;
 use serde_cbor::ser::{IoWrite, Serializer};
+
+#[cfg(not(feature="futures_codec"))]
 use tokio_io::codec::{Decoder as IoDecoder, Encoder as IoEncoder};
+
+#[cfg(feature="futures_codec")]
+use futures_codec::{Decoder as IoDecoder, Encoder as IoEncoder};
 
 /// Errors returned by encoding and decoding.
 #[derive(Debug)]


### PR DESCRIPTION
This adds the possibility to use this codec in order to frame AsyncRead/AsyncWrite from the
futures 0.3 library as well as tokio's version.

Actual implementation of this is a single line. It just requires importing the `Encoder` and `Decoder`
traits from futures_code instead of from tokio-codec. I created an optional dependency
on futures_codec for this.

I have added documentation and and example.

A note on the dev-dependency on futures-preview. I have pinned it to version 0.3.0-alpha.17
because the runtime crate released on crates.io will not compile with futures 0.3.0-alpha.18,
however that last one was released yesterday, so I think this will be fixed soon after which
the pin can be removed.