### PR TITLE
Update to the latest futures & tokio.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ travis-ci = { repository = "vorner/tokio-serde-cbor" }
 appveyor = { repository = "vorner/tokio-serde-cbor" }
 
 [dependencies]
-bytes = "~0.4"
+bytes = "~0.5"
 serde = "~1"
 serde_cbor = "~0.10"
-tokio-io = "~0.1"
+tokio-util = { version = "~0.2", features = ["codec"] }
 
 [dev-dependencies]
-tokio    = "~0.1"
+futures = "~0.3"
+tokio = { version = "~0.2", features = ["dns", "macros", "rt-core", "tcp"] }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,17 +1,10 @@
-extern crate tokio;
-extern crate tokio_serde_cbor;
+use std::collections::HashMap;
 
-use std::net::{TcpListener as StdTcpListener, TcpStream as StdTcpStream};
-
-use tokio::codec::Decoder;
-use tokio::net::tcp::TcpStream;
-use tokio::prelude::*;
-use tokio::reactor::Handle;
-use tokio::runtime::Runtime;
+use futures::prelude::*;
+use tokio::net::{TcpListener, TcpStream};
+use tokio_util::codec::Decoder;
 
 use tokio_serde_cbor::Codec;
-
-use std::collections::HashMap;
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 
@@ -30,51 +23,48 @@ fn test_data() -> TestData {
 /// Creates a connected pair of sockets.
 ///
 /// This is similar to UnixStream::socket_pair, but works on windows too.
-///
-/// This is blocking, so it arguably doesn't belong into an async application, but this is not the
-/// point of the example here.
-fn socket_pair() -> Result<(TcpStream, TcpStream), Error> {
+async fn socket_pair() -> Result<(TcpStream, TcpStream), Error> {
     // port 0 = let the OS choose
-    let listener = StdTcpListener::bind("127.0.0.1:0")?;
-    let stream1 = StdTcpStream::connect(listener.local_addr()?)?;
-    let stream2 = listener.accept()?.0;
-    let stream1 = TcpStream::from_std(stream1, &Handle::default())?;
-    let stream2 = TcpStream::from_std(stream2, &Handle::default())?;
+    let mut listener = TcpListener::bind("127.0.0.1:0").await?;
+    let stream1 = TcpStream::connect(listener.local_addr()?).await?;
+    let stream2 = listener.accept().await?.0;
+
     Ok((stream1, stream2))
 }
 
-fn main() -> Result<(), Error> {
+#[tokio::main]
+async fn main() -> Result<(), Error> {
     // This creates a pair of TCP domain sockets that are connected together.
-    let (sender_socket, receiver_socket) = socket_pair()?;
+    let (sender_socket, receiver_socket) = socket_pair().await?;
 
     // Create the codec, type annotations are needed here.
     let codec: Codec<TestData, TestData> = Codec::new();
 
     // Get read and write parts of our streams (we ignore the other directions, but we could
     // .split() them if we wanted to talk both ways).
-    let sender = codec.clone().framed(sender_socket);
+    let mut sender = codec.clone().framed(sender_socket);
     let receiver = codec.framed(receiver_socket);
 
     // This is the data we will send over.
     let msg1 = test_data();
     let msg2 = test_data();
 
+    let mut msgs = futures::stream::iter(vec![Ok(msg1), Ok(msg2)]);
+
     // Send method comes from Sink and it will return a future we can spawn with tokio.
-    // It consumes self, so we need to chain the next send with then.
-    let send_all = sender
-            .send(msg1)
-            .and_then(|sender| sender.send(msg2))
-            // Close the sink (otherwise it would get returned throughout the join and block_on and
-            // the for_each would wait for more messages).
-            .map(|sender| drop(sender));
+    sender.send_all(&mut msgs).await?;
+
+    // Close the sink (otherwise it would get returned throughout the join and block_on and
+    // the for_each would wait for more messages).
+    sender.close().await?;
 
     // for each frame, thus for each entire object we receive.
     let recv_all = receiver.for_each(|msg| {
         println!("Received: {:#?}", msg);
-        Ok(())
+        return future::ready(());
     });
 
-    Runtime::new()?.block_on_all(send_all.join(recv_all))?;
+    recv_all.await;
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,12 +20,13 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::io::{Error as IoError, Read, Result as IoResult, Write};
 use std::marker::PhantomData;
 
+use bytes::Buf;
 use bytes::BytesMut;
 use serde::{Deserialize, Serialize};
 use serde_cbor::de::{Deserializer, IoRead};
 use serde_cbor::error::Error as CborError;
 use serde_cbor::ser::{IoWrite, Serializer};
-use tokio_io::codec::{Decoder as IoDecoder, Encoder as IoEncoder};
+use tokio_util::codec::{Decoder as IoDecoder, Encoder as IoEncoder};
 
 /// Errors returned by encoding and decoding.
 #[derive(Debug)]
@@ -83,7 +84,7 @@ impl<'a, R: Read> Read for Counted<'a, R> {
             Ok(size) => {
                 *self.pos += size;
                 Ok(size)
-            },
+            }
             e => e,
         }
     }
@@ -132,9 +133,9 @@ impl<'de, Item: Deserialize<'de>> IoDecoder for Decoder<Item> {
         match result {
             // If we read the item, we also need to consume the corresponding bytes.
             Ok(item) => {
-                src.split_to(pos);
+                src.advance(pos);
                 Ok(Some(item))
-            },
+            }
             // Sometimes the EOF is signalled as IO error
             Err(ref error) if error.is_eof() => Ok(None),
             // Any other error is simply passed through.


### PR DESCRIPTION
Hi Michal!

Thanks for this lib, it helped me a lot to get my head around with tokio, serde and async.

I am looking to use it in my pet project with up to date tokio which is incompatible with the one used by the crate.

This PR updates tokio to the latest (0.2.6 at this stage) which more or less has migrated to latest futures. However, it still uses Encoder/Decoder from tokio rather than futures-codec.

Would you consider merging it in?