### PR TITLE
Update tokio-util version to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ appveyor = { repository = "vorner/tokio-serde-cbor" }
 bytes = "~1"
 serde = "~1"
 serde_cbor = "~0.11.1"
-tokio-util = { version = "~0.6", features = ["codec"] }
+tokio-util = { version = "~0.7", features = ["codec"] }
 
 [dev-dependencies]
 futures = "~0.3"


### PR DESCRIPTION
Not sure how you'd prefer to bump the package version. Release tokio-serde-cbor v0.7 or 0.6.1?